### PR TITLE
fix: change ETH pubkey style uncompressed to compressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-typescript": "^7.22.15",
     "@jest/globals": "^29.7.0",
     "@tsconfig/recommended": "^1.0.3",
+    "@types/elliptic": "^6.4.16",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.6.3",
     "@types/secure-random": "^1.1.0",
@@ -57,9 +58,10 @@
     "bs58": "^5.0.0",
     "bs58check": "^3.0.1",
     "eccrypto-js": "^5.4.0",
-    "ethereumjs-wallet": "^1.0.2",
+    "elliptic": "^6.5.4",
+    "ethers": "^6.7.0",
     "int64-buffer": "^1.0.1",
-    "js-sha3": "^0.9.2",
+    "js-sha3": "^0.8.0",
     "secure-random": "^1.1.2"
   }
 }

--- a/src/key/index.ts
+++ b/src/key/index.ts
@@ -1,16 +1,17 @@
 import { KeyPairType, AddressType, Account } from "./types"
 
 import { randomN } from "./random"
-import { Keys, Key, PubKey } from "./pub"
+import { Keys, Key, PubKey, EtherKeys } from "./pub"
 import { BaseKeyPair, KeyPair } from "./keypair"
 import { Address, ZeroAddress, NodeAddress } from "./address"
 
 import { Big, Generator, IP } from "../types"
+import { Assert, ECODE, MitumError } from "../error"
 
 export {
     KeyPairType, AddressType, Account,
     Address, ZeroAddress, NodeAddress,
-    Key, Keys, PubKey,
+    Key, Keys, PubKey, EtherKeys,
     BaseKeyPair, KeyPair,
     randomN,
 }
@@ -99,11 +100,21 @@ export class KeyG extends Generator {
     }
 
     address(key: string | Key): string {
+        const suffix = key.toString().slice(-3);
+        Assert.check(
+            suffix === "mpu",
+            MitumError.detail(ECODE.INVALID_PUBLIC_KEY, "invalid pubkey format"),
+        )
         return new Keys([new PubKey(key, 100)], 100).address.toString()
     }
 
     etherAddress(key: string | Key): string {
-        return new Keys([new PubKey(key, 100)], 100).etherAddress.toString()
+        const suffix = key.toString().slice(-3);
+        Assert.check(
+            suffix === "epu",
+            MitumError.detail(ECODE.INVALID_PUBLIC_KEY, "invalid pubkey format"),
+        )
+        return new EtherKeys([new PubKey(key, 100)], 100).etherAddress.toString()
     }
 
     addressForMultiSig(
@@ -117,6 +128,6 @@ export class KeyG extends Generator {
         keys: keysType,
         threshold: string | number | Big,
     ): string {
-        return new Keys(keys.map(k => k instanceof PubKey ? k : new PubKey(k.key, k.weight)), threshold).etherAddress.toString()
+        return new EtherKeys(keys.map(k => k instanceof PubKey ? k : new PubKey(k.key, k.weight)), threshold).etherAddress.toString()
     }
 }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -67,7 +67,7 @@ export const Config = {
 		},
 		ETHER: {
 			PRIVATE: getRangeConfig(67),
-			PUBLIC: getRangeConfig(133),
+			PUBLIC: getRangeConfig(69),
 		}
 	},
 	NFT: {

--- a/src/operation/currency/create-account.ts
+++ b/src/operation/currency/create-account.ts
@@ -7,14 +7,14 @@ import { Amount } from "../../common"
 import { SortFunc } from "../../utils"
 import { HINT, SUFFIX } from "../../alias"
 import { HintedObject } from "../../types"
-import { Keys, Address, AddressType } from "../../key"
+import { Keys, EtherKeys, Address, AddressType } from "../../key"
 import { Assert, ECODE, MitumError } from "../../error"
 
 export class CreateAccountItem extends CurrencyItem {
-    readonly keys: Keys
+    readonly keys: Keys | EtherKeys;
     private addressSuffix: string
 
-    constructor(keys: Keys, amounts: Amount[], addressType: AddressType) {
+    constructor(keys: Keys | EtherKeys, amounts: Amount[], addressType: AddressType) {
         super(HINT.CURRENCY.CREATE_ACCOUNT.ITEM, amounts, addressType)
         this.keys = keys
 

--- a/src/operation/currency/create-contract-account.ts
+++ b/src/operation/currency/create-contract-account.ts
@@ -7,14 +7,14 @@ import { Amount } from "../../common"
 import { SortFunc } from "../../utils"
 import { HINT, SUFFIX } from "../../alias"
 import { HintedObject } from "../../types"
-import { Keys, AddressType, Address } from "../../key"
+import { Keys, AddressType, Address, EtherKeys } from "../../key"
 import { Assert, ECODE, MitumError } from "../../error"
 
 export class CreateContractAccountItem extends CurrencyItem {
-    readonly keys: Keys
+    readonly keys: Keys | EtherKeys
     private addressSuffix: string
     
-    constructor(keys: Keys, amounts: Amount[], addressType: AddressType) {
+    constructor(keys: Keys | EtherKeys, amounts: Amount[], addressType: AddressType) {
         super(HINT.CURRENCY.CREATE_CONTRACT_ACCOUNT.ITEM, amounts, addressType)
         this.keys = keys
 

--- a/src/operation/currency/index.ts
+++ b/src/operation/currency/index.ts
@@ -512,7 +512,7 @@ export class Contract extends Generator {
         weight?: string | number | Big,
     ): { wallet: AccountType, operation: Operation<CreateContractAccountFact> } {
         const kp = seed ? KeyPair.fromSeed(seed, "ether") : KeyPair.random("ether")
-        const ks = new Keys([new PubKey(kp.publicKey, weight ?? 100)], weight ?? 100)
+        const ks = new EtherKeys([new PubKey(kp.publicKey, weight ?? 100)], weight ?? 100)
 
         return {
             wallet: {

--- a/src/operation/currency/index.ts
+++ b/src/operation/currency/index.ts
@@ -16,7 +16,7 @@ import api, { getAPIData } from "../../api"
 import { Amount, CurrencyID } from "../../common"
 import { Assert, ECODE, MitumError } from "../../error"
 import { Big, Generator, IP, TimeStamp } from "../../types"
-import { Address, Key, KeyPair, Keys, PubKey, Account as AccountType, KeyG } from "../../key"
+import { Address, Key, KeyPair, Keys, PubKey, Account as AccountType, KeyG, EtherKeys } from "../../key"
 
 type createData = {
     currency: string | CurrencyID
@@ -232,7 +232,40 @@ export class Account extends KeyG {
         }
     }
 
-    create(
+    createEtherWallet(
+        sender: string | Address,
+        currency: string | CurrencyID,
+        amount: string | number | Big,
+        seed?: string,
+        weight?: string | number | Big,
+    ): { wallet: AccountType, operation: Operation<CreateAccountFact> } {
+        const kp = seed ? KeyPair.fromSeed(seed, "ether") : KeyPair.random("ether")
+        const ks = new EtherKeys([new PubKey(kp.publicKey, weight ?? 100)], weight ?? 100)
+
+        return {
+            wallet: {
+                privatekey: kp.privateKey.toString(),
+                publickey: kp.publicKey.toString(),
+                address: this.etherAddress(kp.publicKey),
+            },
+            operation: new Operation(
+                this.networkID,
+                new CreateAccountFact(
+                    TimeStamp.new().UTC(),
+                    sender,
+                    [
+                        new CreateAccountItem(
+                            ks,
+                            [new Amount(currency, amount)],
+                            "ether",
+                        )
+                    ],
+                ),
+            ),
+        }
+    }
+
+    createAccount(
         sender: string | Address,
         key: string | Key | PubKey,
         currency: string | CurrencyID,
@@ -267,7 +300,7 @@ export class Account extends KeyG {
                 sender,
                 [
                     new CreateAccountItem(
-                        new Keys([new PubKey(key, 100)], 100),
+                        new EtherKeys([new PubKey(key, 100)], 100),
                         [new Amount(currency, amount)],
                         "ether",
                     )
@@ -337,12 +370,24 @@ export class Account extends KeyG {
         newKey: string | Key | PubKey,
         currency: string | CurrencyID,
     ) {
+        const suffix = target.toString().slice(-3)
+        if (suffix === "mca") {
+            return new Operation(
+                this.networkID,
+                new UpdateKeyFact(
+                    TimeStamp.new().UTC(),
+                    target,
+                    new Keys([new PubKey(newKey, 100)], 100),
+                    currency,
+                ),
+            )
+        }
         return new Operation(
             this.networkID,
             new UpdateKeyFact(
                 TimeStamp.new().UTC(),
                 target,
-                new Keys([new PubKey(newKey, 100)], 100),
+                new EtherKeys([new PubKey(newKey, 100)], 100),
                 currency,
             ),
         )
@@ -354,12 +399,29 @@ export class Account extends KeyG {
         currency: string | CurrencyID,
         threshold: string | number | Big,
     ) {
+        const suffix = target.toString().slice(-3)
+        if (suffix === "mca") {
+            return new Operation(
+                this.networkID,
+                new UpdateKeyFact(
+                    TimeStamp.new().UTC(),
+                    target,
+                    new Keys(
+                        newKeys.map(k =>
+                            k instanceof PubKey ? k : new PubKey(k.key, k.weight)
+                        ),
+                        threshold,
+                    ),
+                    currency,
+                ),
+            )
+        } 
         return new Operation(
             this.networkID,
             new UpdateKeyFact(
                 TimeStamp.new().UTC(),
                 target,
-                new Keys(
+                new EtherKeys(
                     newKeys.map(k =>
                         k instanceof PubKey ? k : new PubKey(k.key, k.weight)
                     ),
@@ -442,7 +504,40 @@ export class Contract extends Generator {
         }
     }
 
-    create(
+    createEtherWallet(
+        sender: string | Address,
+        currency: string | CurrencyID,
+        amount: string | number | Big,
+        seed?: string,
+        weight?: string | number | Big,
+    ): { wallet: AccountType, operation: Operation<CreateContractAccountFact> } {
+        const kp = seed ? KeyPair.fromSeed(seed, "ether") : KeyPair.random("ether")
+        const ks = new Keys([new PubKey(kp.publicKey, weight ?? 100)], weight ?? 100)
+
+        return {
+            wallet: {
+                privatekey: kp.privateKey.toString(),
+                publickey: kp.publicKey.toString(),
+                address: new EtherKeys([new PubKey(kp.publicKey, 100)], 100).etherAddress.toString(),
+            },
+            operation: new Operation(
+                this.networkID,
+                new CreateContractAccountFact(
+                    TimeStamp.new().UTC(),
+                    sender,
+                    [
+                        new CreateContractAccountItem(
+                            ks,
+                            [new Amount(currency, amount)],
+                            "ether",
+                        )
+                    ],
+                ),
+            ),
+        }
+    }
+
+    createAccount(
         sender: string | Address,
         key: string | Key | PubKey,
         currency: string | CurrencyID,
@@ -477,7 +572,7 @@ export class Contract extends Generator {
                 sender,
                 [
                     new CreateContractAccountItem(
-                        new Keys([new PubKey(key, 100)], 100),
+                        new EtherKeys([new PubKey(key, 100)], 100),
                         [new Amount(currency, amount)],
                         "ether",
                     )
@@ -528,7 +623,7 @@ export class Contract extends Generator {
                 sender,
                 [
                     new CreateContractAccountItem(
-                        new Keys(
+                        new EtherKeys(
                             keys.map(k =>
                                 k instanceof PubKey ? k : new PubKey(k.key, k.weight)
                             ),

--- a/src/operation/currency/update-key.ts
+++ b/src/operation/currency/update-key.ts
@@ -2,14 +2,14 @@ import { Fact, FactJson } from "../base"
 
 import { HINT } from "../../alias"
 import { CurrencyID } from "../../common"
-import { Address, Keys } from "../../key"
+import { Address, EtherKeys, Keys } from "../../key"
 
 export class UpdateKeyFact extends Fact {
     readonly target: Address
-    readonly keys: Keys
+    readonly keys: Keys | EtherKeys
     readonly currency: CurrencyID
 
-    constructor(token: string, target: string | Address, keys: Keys, currency: string | CurrencyID) {
+    constructor(token: string, target: string | Address, keys: Keys | EtherKeys, currency: string | CurrencyID) {
         super(HINT.CURRENCY.UPDATE_KEY.FACT, token)
         this.target = Address.from(target)
         this.keys = keys

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -1,0 +1,34 @@
+import { getPublicKey } from "@noble/secp256k1"
+
+export const privateKeyToPublicKey = (
+  privateKey: string | Buffer
+): Uint8Array => {
+  let privateBuf: Buffer;
+
+  if (!Buffer.isBuffer(privateKey)) {
+    if (typeof privateKey !== "string") {
+      throw new Error("Expected Buffer or string as argument");
+    }
+
+    privateKey =
+      privateKey.slice(0, 2) === "0x" ? privateKey.slice(2) : privateKey;
+    privateBuf = Buffer.from(privateKey, "hex");
+  } else {
+    privateBuf = privateKey;
+  }
+
+  return getPublicKey(privateBuf, false);
+};
+
+export const compress = (publicKey: Uint8Array): string => {
+  const xCoordinate = publicKey.slice(1, 33);
+
+  const yCoordinate = publicKey.slice(33);
+
+  const compressedPublicKey = Buffer.concat([
+    Buffer.from([0x02 + (yCoordinate[yCoordinate.length - 1] % 2)]),
+    xCoordinate,
+  ]);
+
+  return compressedPublicKey.toString("hex");
+};


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 
- change ETH pubkey style uncompressed to compressed
- change function name ( account.create, contract.create => account.createAccount, contract.createAccount)
- add function (account.creatEtherWallet, contract.createEtherWallet)
- now eth-styled account(both eoa, ca) can be deployed using (createAccount, 
### Current Behavior (Link to an open issue)
- 
### New Behavior (if this is a feature change)
-
### Other information
-
