### PR TITLE
feat: add createBatchWallet function

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -58,7 +58,7 @@ export const Config = {
 	},
 	KEYS_IN_ACCOUNT: getRangeConfig(1, 10),
 	AMOUNTS_IN_ITEM: getRangeConfig(1, 10),
-	ITEMS_IN_FACT: getRangeConfig(1, 10),
+	ITEMS_IN_FACT: getRangeConfig(1, 100),
 	OPERATIONS_IN_SEAL: getRangeConfig(1, 10),
 	KEY: {
 		MITUM: {

--- a/src/operation/currency/index.ts
+++ b/src/operation/currency/index.ts
@@ -277,6 +277,28 @@ export class Account extends KeyG {
         }
     }
 
+    createBatchWallet(
+        sender: string | Address,
+        n: number,
+        currency: string | CurrencyID,
+        amount: string | number | Big,
+    ): { wallet: AccountType[], operation: Operation<CreateAccountFact> } {
+        const keyArray = this.keys(n);
+        const ksArray = keyArray.map((key) => new Keys([new PubKey(key.publickey, 100)], 100));
+        const items = ksArray.map((ks) => new CreateAccountItem(ks,[new Amount(currency, amount)],"mitum",));
+        return {
+            wallet: keyArray,
+            operation: new Operation(
+                this.networkID,
+                new CreateAccountFact(
+                    TimeStamp.new().UTC(),
+                    sender,
+                    items,
+                ),
+            ),
+        }
+    }
+
     createAccount(
         sender: string | Address,
         key: string | Key | PubKey,


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 

- add `createBatchWallet()` for create-account operation include multiple items
- increase maximum limit of items in one fact (10 -> 100)

### Current Behavior (Link to an open issue)

-
-

### New Behavior (if this is a feature change)

-
-

### Other information

-
-
