### PR TITLE
feat: add delegate uri path to post and some get functions

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -2,12 +2,18 @@ import axios from "axios"
 import { IP } from "../types";
 import { Address, Key } from "../key";
 
-async function getAccount(api: string | IP, address: string | Address) {
-    return await axios.get(`${IP.from(api).toString()}/account/${Address.from(address).toString()}`)
+const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+
+async function getAccount(api: string | IP, address: string | Address, delegate? : boolean | undefined) {
+    const apiPath = `${IP.from(api).toString()}/account/${Address.from(address).toString()}`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
-async function getAccountByPublicKey(api: string | IP, publicKey: string | Key) {
-    return await axios.get(`${IP.from(api).toString()}/accounts?publickey=${Key.from(publicKey).toString()}`)
+async function getAccountByPublicKey(api: string | IP, publicKey: string | Key, delegate? : boolean | undefined) {
+    const apiPath = `${IP.from(api).toString()}/accounts?publickey=${Key.from(publicKey).toString()}`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
 export default {

--- a/src/api/models/currency.ts
+++ b/src/api/models/currency.ts
@@ -2,12 +2,18 @@ import axios from "axios"
 import { IP } from "../../types"
 import { CurrencyID } from "../../common"
 
-async function getCurrencies(api: string | IP) {
-    return await axios.get(`${IP.from(api).toString()}/currency`)
+const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+
+async function getCurrencies(api: string | IP, delegate? : boolean | undefined) {
+    const apiPath = `${IP.from(api).toString()}/currency`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
-async function getCurrency(api: string | IP, currency: string | CurrencyID) {
-    return await axios.get(`${IP.from(api).toString()}/currency/${CurrencyID.from(currency).toString()}`)
+async function getCurrency(api: string | IP, currency: string | CurrencyID, delegate? : boolean | undefined) {
+    const apiPath = `${IP.from(api).toString()}/currency/${CurrencyID.from(currency).toString()}`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
 export default {

--- a/src/api/models/sto.ts
+++ b/src/api/models/sto.ts
@@ -8,19 +8,27 @@ const url = (
     contract: string | Address, 
 ) => `${IP.from(api).toString()}/sto/${Address.from(contract).toString()}`
 
+const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+
 async function getService(
     api: string | IP, 
     contract: string | Address,
+    delegate: boolean | undefined,
 ) {
-    return await axios.get(`${url(api, contract)}`)
+    const apiPath = `${url(api, contract)}`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
 async function getPartitions(
     api: string | IP, 
     contract: string | Address,
     holder: string | Address,
+    delegate? : boolean | undefined,
 ) {
-    return await axios.get(`${url(api, contract)}/holder/${Address.from(holder).toString()}/partitions`)
+    const apiPath = `${url(api, contract)}/holder/${Address.from(holder).toString()}/partitions`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
 async function getBalanceByHolder(
@@ -28,8 +36,11 @@ async function getBalanceByHolder(
     contract: string | Address,
     holder: string | Address,
     partition: string,
+    delegate? : boolean | undefined,
 ) {
-    return await axios.get(`${url(api, contract)}/holder/${Address.from(holder).toString()}/partition/${partition}/balance`)
+    const apiPath = `${url(api, contract)}/holder/${Address.from(holder).toString()}/partition/${partition}/balance`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
 async function getOperatorsByHolder(

--- a/src/api/models/token.ts
+++ b/src/api/models/token.ts
@@ -19,8 +19,12 @@ async function getTokenBalance(
     api: string | IP,
     contract: string | Address,
     account: string | Address,
+    delegate: boolean | undefined
 ) {
-    return await axios.get(`${url(api, contract)}/account/${Address.from(account).toString()}`)
+    const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+    const apiPath = `${url(api, contract)}/account/${Address.from(account).toString()}`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
 export default {

--- a/src/api/operation.ts
+++ b/src/api/operation.ts
@@ -2,12 +2,16 @@ import axios from "axios"
 import { Address } from "../key"
 import { Big, HintedObject, IP } from "../types"
 
+const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+
 async function getOperations(api: string | IP) {
     return await axios.get(`${IP.from(api).toString()}/block/operations`)
 }
 
-async function getOperation(api: string | IP, hash: string) {
-    return await axios.get(`${IP.from(api).toString()}/block/operation/${hash}`)
+async function getOperation(api: string | IP, hash: string, delegate?: boolean | undefined) {
+    const apiPath = `${IP.from(api).toString()}/block/operation/${hash}`;
+    const encodedString = encodeURIComponent(apiPath);
+    return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 
 }
 
 async function getBlockOperationsByHeight(api: string | IP, height: string | number | Big) {
@@ -26,6 +30,11 @@ async function send(api: string | IP, operation: HintedObject | string, config?:
     return await axios.post(`${IP.from(api).toString()}/builder/send`, JSON.stringify(operation), config)
 }
 
+async function delegateSend(operation: HintedObject | string, config?: { [i: string]: any }) {
+    const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call";
+    return await axios.post(delegateAddress, JSON.stringify(operation), config)
+}
+
 export default {
     getOperations,
     getOperation,
@@ -33,4 +42,5 @@ export default {
     getBlockOperationsByHash,
     getAccountOperations,
     send,
+    delegateSend,
 }

--- a/src/operation/currency/index.ts
+++ b/src/operation/currency/index.ts
@@ -188,8 +188,8 @@ export class Currency extends Generator {
         )
     }
 
-    async getAllCurrencies(): Promise<string[] | null> {
-        const datas = await getAPIData(() => api.currency.getCurrencies(this.api))
+    async getAllCurrencies(delegate? : boolean | undefined): Promise<string[] | null> {
+        const datas = await getAPIData(() => api.currency.getCurrencies(this.api, delegate))
 
         return datas
             ? Object.keys(datas._links).filter(
@@ -197,8 +197,8 @@ export class Currency extends Generator {
             : null
     }
 
-    async getCurrency(cid: string | CurrencyID) {
-        const data = await getAPIData(() => api.currency.getCurrency(this.api, cid))
+    async getCurrency(cid: string | CurrencyID, delegate? : boolean | undefined) {
+        const data = await getAPIData(() => api.currency.getCurrency(this.api, cid, delegate))
         return data ? data._embedded : null
     }
 }
@@ -490,8 +490,8 @@ export class Account extends KeyG {
         return await getAPIData(() => api.operation.send(this.api, op.toHintedObject()))
     }
 
-    async getAccountInfo(address: string | Address) {
-        const data = await getAPIData(() => api.account.getAccount(this.api, address))
+    async getAccountInfo(address: string | Address, delegate?: boolean | undefined) {
+        const data = await getAPIData(() => api.account.getAccount(this.api, address, delegate))
         return data ? data._embedded : null
     }
 
@@ -500,13 +500,13 @@ export class Account extends KeyG {
         return data ? data._embedded : null
     }
 
-    async getByPublickey(publickey: string | Key | PubKey) {
-        const data = await getAPIData(() => api.account.getAccountByPublicKey(this.api, publickey))
+    async getByPublickey(publickey: string | Key | PubKey, delegate?: boolean | undefined) {
+        const data = await getAPIData(() => api.account.getAccountByPublicKey(this.api, publickey, delegate))
         return data ? data._embedded : null
     }
 
-    async balance(address: string | Address) {
-        const data = await getAPIData(() => api.account.getAccount(this.api, address))
+    async balance(address: string | Address, delegate?: boolean | undefined) {
+        const data = await getAPIData(() => api.account.getAccount(this.api, address, delegate))
         return data ? data._embedded.balance : null
     }
 }

--- a/src/operation/index.ts
+++ b/src/operation/index.ts
@@ -29,8 +29,8 @@ export class Operation extends Generator {
 		return await api.getOperations(this.api)
 	}
 
-	async getOperation(hash: string) {
-		return await api.getOperation(this.api, hash)
+	async getOperation(hash: string, delegate?: boolean | undefined) {
+		return await api.getOperation(this.api, hash, delegate)
 	}
 
 	sign(
@@ -48,6 +48,13 @@ export class Operation extends Generator {
 		headers?: { [i: string]: any }
 	) {
 		return await api.send(this.api, operation, headers)
+	}
+
+	async delegateSend(
+		operation: string | HintedObject,
+		headers?: { [i: string]: any }
+	) {
+		return await api.delegateSend(operation, headers)
 	}
 }
 

--- a/src/operation/sto/index.ts
+++ b/src/operation/sto/index.ts
@@ -206,16 +206,16 @@ export class STO extends ContractGenerator {
         )
     }
 
-    async getServiceInfo(contractAddr: string | Address) {
-        return await getAPIData(() => contract.sto.getService(this.api, contractAddr))
+    async getServiceInfo(contractAddr: string | Address, delegate? : boolean | undefined) {
+        return await getAPIData(() => contract.sto.getService(this.api, contractAddr, delegate))
     }
 
-    async getPartitionsInfo(contractAddr: string | Address, holder: string | Address) {
-        return await getAPIData(() => contract.sto.getPartitions(this.api, contractAddr, holder))
+    async getPartitionsInfo(contractAddr: string | Address, holder: string | Address, delegate? : boolean | undefined) {
+        return await getAPIData(() => contract.sto.getPartitions(this.api, contractAddr, holder, delegate))
     }
     
-    async getBalanceByHolder(contractAddr: string | Address, holder: string | Address, partition: string) {
-        return await getAPIData(() => contract.sto.getBalanceByHolder(this.api, contractAddr, holder, partition))
+    async getBalanceByHolder(contractAddr: string | Address, holder: string | Address, partition: string, delegate? : boolean | undefined) {
+        return await getAPIData(() => contract.sto.getBalanceByHolder(this.api, contractAddr, holder, partition, delegate))
     }
 
     async getOperatorsByHolder(contractAddr: string | Address, holder: string | Address, partition: string) {

--- a/src/operation/token/index.ts
+++ b/src/operation/token/index.ts
@@ -172,8 +172,8 @@ export class Token extends ContractGenerator {
         }
     }
 
-    async getTokenBalance(contractAddr: string | Address, owner: string | Address) {
-        const data = await getAPIData(() => contract.token.getTokenBalance(this.api, contractAddr, owner))
+    async getTokenBalance(contractAddr: string | Address, owner: string | Address, delegate? : boolean | undefined) {
+        const data = await getAPIData(() => contract.token.getTokenBalance(this.api, contractAddr, owner, delegate))
         return data ? data._embedded : null
     }
 }


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 

- add `delegateSend()` function for POST operation through delegate server
- add boolean option called `delegate` to  following get functions : 
✅mitum.account.getAccountInfo 
✅mitum.account.getByPublickey
✅mitum.account.balance
✅mitum.operation.getOperation
✅mitum.currency.getAllCurrencies
✅mitum.currency.getCurrency
✅mitum.token.getTokenBalance
✅mitum.sto.getServiceInfo
✅mitum.sto.getPartitionsInfo
✅mitum.sto.getBalanceByHolder

### Current Behavior (Link to an open issue)

-
-

### New Behavior (if this is a feature change)

-
-

### Other information

-
-
