### PR TITLE
feat: fix delegate path

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -2,7 +2,7 @@ import axios from "axios"
 import { IP } from "../types";
 import { Address, Key } from "../key";
 
-const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+const delegateAddress = "http://152.99.22.116:444/v1/mitumt/delegate/call?uri="
 
 async function getAccount(api: string | IP, address: string | Address, delegate? : boolean | undefined) {
     const apiPath = `${IP.from(api).toString()}/account/${Address.from(address).toString()}`;

--- a/src/api/models/currency.ts
+++ b/src/api/models/currency.ts
@@ -2,7 +2,7 @@ import axios from "axios"
 import { IP } from "../../types"
 import { CurrencyID } from "../../common"
 
-const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+const delegateAddress = "http://152.99.22.116:444/v1/mitumt/delegate/call?uri="
 
 async function getCurrencies(api: string | IP, delegate? : boolean | undefined) {
     const apiPath = `${IP.from(api).toString()}/currency`;

--- a/src/api/models/sto.ts
+++ b/src/api/models/sto.ts
@@ -8,7 +8,7 @@ const url = (
     contract: string | Address, 
 ) => `${IP.from(api).toString()}/sto/${Address.from(contract).toString()}`
 
-const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+const delegateAddress = "http://152.99.22.116:444/v1/mitumt/delegate/call?uri="
 
 async function getService(
     api: string | IP, 

--- a/src/api/models/token.ts
+++ b/src/api/models/token.ts
@@ -21,7 +21,7 @@ async function getTokenBalance(
     account: string | Address,
     delegate: boolean | undefined
 ) {
-    const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+    const delegateAddress = "http://152.99.22.116:444/v1/mitumt/delegate/call?uri="
     const apiPath = `${url(api, contract)}/account/${Address.from(account).toString()}`;
     const encodedString = encodeURIComponent(apiPath);
     return !delegate ? await axios.get(apiPath) : await axios.get(delegateAddress + encodedString) 

--- a/src/api/operation.ts
+++ b/src/api/operation.ts
@@ -2,7 +2,7 @@ import axios from "axios"
 import { Address } from "../key"
 import { Big, HintedObject, IP } from "../types"
 
-const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call?uri="
+const delegateAddress = "http://152.99.22.116:444/v1/mitumt/delegate/call?uri="
 
 async function getOperations(api: string | IP) {
     return await axios.get(`${IP.from(api).toString()}/block/operations`)
@@ -31,8 +31,8 @@ async function send(api: string | IP, operation: HintedObject | string, config?:
 }
 
 async function delegateSend(operation: HintedObject | string, config?: { [i: string]: any }) {
-    const delegateAddress = "http://localhost:5598/v1/mitumt/delegate/call";
-    return await axios.post(delegateAddress, JSON.stringify(operation), config)
+    const delegateAddress = "http://152.99.22.116:444/v1/mitumt/delegate/call";
+    return await axios.post(delegateAddress, operation, config)
 }
 
 export default {


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 

- feat: fix delegate path
- fix delegatesend function to send an `operation` other than `JSON.stringify(operation)`.

### Current Behavior (Link to an open issue)

-
-

### New Behavior (if this is a feature change)

-
-

### Other information

-
-
