### PR TITLE
fix: EC_INVALID_KEY error in secureRandom key generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 **.DS_Store
 
-cjs/
-esm/
+dist/
 .idea/

--- a/src/key/keypair.ts
+++ b/src/key/keypair.ts
@@ -145,8 +145,16 @@ export class KeyPair extends BaseKeyPair {
             option = option ?? "btc"
     
             if (option === "btc") {
+                const safeRandomArray = () => {
+                    while (true) {
+                        const randomArray = secureRandom(32, { type: "Uint8Array" }); 
+                        if (randomArray[0] !== 0) {
+                            return randomArray
+                        }
+                    }
+                }
                 return new KeyPair(
-                    base58.encode(Buffer.from(secureRandom(32, { type: "Uint8Array" }))) + SUFFIX.KEY.MITUM.PRIVATE
+                    base58.encode(Buffer.from(safeRandomArray())) + SUFFIX.KEY.MITUM.PRIVATE
                 )
             }
     

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -25,8 +25,8 @@ export class Node extends Generator {
 }
 
 export class Block extends Generator {
-    constructor(api?: string | IP, delegate?: string | IP) {
-        super("", api, delegate)
+    constructor(api?: string | IP, delegateIP?: string | IP) {
+        super("", api, delegateIP)
     }
 
     async getAllBlocks() {


### PR DESCRIPTION
### Pull-request Type (fix, feat, bug, doc, chore, test, etc...) 
- docs: .gitignore
  ignore `/dist` directory
- fix: EC_INVALID_KEY error in secureRandom key generation
    When generating a key randomly without a seed, an error called `EC_INVALID_KEY` rarely occurred.
    Normally it would be very rare, but this problem becomes noticeable when creating batch accounts.
    The error occurs when **the first argument of the return value of the `secureRandom`** function, which returns a random array of type `Uint8Array`, **is 0**.
    (If the first argument is 0, the error occurs because the length of the private key is 45 instead of 47. `secureRandom` is not used to generate ether style keys.)
    Therefore, if the first argument is 0, the random array has been modified to be recalculated.

### Current Behavior (Link to an open issue)

-
-

### New Behavior (if this is a feature change)

-
-

### Other information

-
-
